### PR TITLE
Added AI-Hub kspon(Korean speech dataset) related scripts

### DIFF
--- a/s5/data/local/lm/buildLM/_scripts_/genPronunciation_cmu.py
+++ b/s5/data/local/lm/buildLM/_scripts_/genPronunciation_cmu.py
@@ -1697,7 +1697,7 @@ def fUpper(match):
     return match.group(0).upper()
 
 def main():
-    filename='buildLM/_scripts_/cmudict-0.7b.txt'
+    filename=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'cmudict-0.7b.txt')
     if not os.path.exists(filename):
         print('No dictionary file: %s' % filename)
         sys.exit()

--- a/s5/local/generateExtraLexicon.sh
+++ b/s5/local/generateExtraLexicon.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Copyright 2019 hwiorn <hwiorn@gmail.com>
+# Apache 2.0
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <data-dir> <lm-dir>"
+    echo "   ex: $0 data/kspon data/local/lm"
+    exit 1
+fi
+data_dir=$1
+lm_dir=$2
+
+text=$data_dir/text
+script_dir=$lm_dir/buildLM/_scripts_
+
+if [ ! -f $text ]; then
+	echo $0: No such file: $text
+	exit 1
+fi
+
+if [ ! -f $script_dir/cmudict-0.7b.txt ]; then
+	echo $0: No such cmudict dictionary file.
+	exit 1
+fi
+
+cut -d' ' -f2- $text > $text.tmp
+echo "$0: Segmenting word class"
+cat $text.tmp |\
+	perl -Mutf8 -CS -pe 's/(?<=[가-힣])([^ 가-힣])/ \1/g; s/(?<=[^ 가-힣])([가-힣])/ \1/g;
+			     s/(?<=[a-zA-Z])([^ a-zA-Z])/ \1/g; s/(?<=[^ a-zA-Z])([a-zA-Z])/ \1/g;
+			     s/(?<=[0-9])([^0-9])/ \1/g; s/(?<=[^0-9])([0-9])/ \1/g' >\
+		$text.tmp2
+
+echo "$0: Generating unique word from AM text"
+parallel -a $text.tmp2 --pipepart --block=11M tr -s '[:space:]' '\\n' \| env LC_ALL=C sort -u | env LC_ALL=C sort -u > $data_dir/uniqWords.txt
+
+grep -P '[가-힣]+_?' $data_dir/uniqWords.txt  | env LC_ALL=C sort -u > $data_dir/uniqWords.hangul
+grep -v -P '[가-힣]+_?' $data_dir/uniqWords.txt | env LC_ALL=C sort -u > $data_dir/uniqWords.nonhangul
+cat $data_dir/uniqWords.nonhangul | grep -E "^[A-Z]+_? " > $data_dir/uniqWords.nonhangul.alphabet
+cat $data_dir/uniqWords.nonhangul | grep -v -E "^[A-Z]+_? " | awk '{print $1}' > $data_dir/uniqWords.nonhangul.etc
+cat $data_dir/uniqWords.nonhangul.{alphabet,etc} | env LC_ALL=C sort -u > $data_dir/uniqWords.nonhangul.sorted
+
+echo "$0: Generating pronunciation for non-hangul morphemes"
+env LC_ALL=en_US.UTF-8 $script_dir/genPronunciation_cmu.py $data_dir/uniqWords.nonhangul.sorted > $data_dir/tmp
+env LC_ALL=en_US.UTF-8 $script_dir/genPronunciation.py $data_dir/tmp > $data_dir/tmp2
+
+awk -F'\t' '{if(NF>1){print $0}}' $data_dir/tmp2 > $data_dir/uniqWords.nonhangul.sorted.pron
+awk -F'\t' '{if(NF<2){print $0}}' $data_dir/tmp2 > $data_dir/noPronList
+noPronCount=$(wc -l <$data_dir/noPronList)
+if [ $noPronCount -ne 0 ]; then
+        echo $0: There exist morphemes without pronunciation, plz check noPronList: $noPronCount
+        head $data_dir/noPronList
+        echo "... (omitted) ..."
+        #rm -f $data_dir/noPronList
+        #exit 1
+fi
+
+echo $0: Generating pronunciation
+cat $data_dir/uniqWords.nonhangul.sorted.pron $data_dir/uniqWords.hangul > $data_dir/finalList
+env LC_ALL=en_US.UTF-8 $script_dir/genPhoneSeq.py $data_dir/finalList
+
+echo $0: Extracting uniq lexicon
+env LC_ALL=en_US.UTF-8 $script_dir/genLexicon.py dic.pronun | perl -pe 's/^\s+$//g' > $data_dir/extra_lexicon.tmp
+utils/filter_scp.pl --exclude $lm_dir/zeroth_lexicon $data_dir/extra_lexicon.tmp > $data_dir/extra_lexicon
+mv -f dic.pronun $data_dir/dic.pronun
+
+[ ! -s $data_dir/noPronList ] && rm -f $data_dir/noPronList
+[ ! -s $data_dir/extra_lexicon ] && rm -f $data_dir/extra_lexicon
+
+rm -f $text.tmp* $data_dir/tmp* $data_dir/*.tmp* $data_dir/uniqWords.* $data_dir/{dic.pronun,finalList,pronoun.dict}
+echo $0: done
+
+exit 0

--- a/s5/local/kspon_data_prep.sh
+++ b/s5/local/kspon_data_prep.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# Copyright 2019   hwiorn <hwiorn@gmail.com>
+# Apache 2.0.
+
+nj=8
+max_gen=10
+
+. ./cmd.sh
+. ./path.sh
+. ./utils/parse_options.sh
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <src-dir> <dst-dir>"
+    echo "e.g.: $0 /mnt/data/aihub/KsponSpeechAll data/aihub_kspon"
+    exit 1
+fi
+
+src=${1%/}
+dst=${2%/}
+
+echo "$0: Data preparation for AI Hub Korean speech datasets(2000 speakers, ~1000hrs)"
+mkdir -p $dst || exit 1
+
+[ ! -d $src ] && echo "$0: no such directory $src" && exit 1
+part_dirs=( $src/KsponSpeech_0{1,2,3,4,5} )
+
+echo $0: Unzipping datasets ...
+for part in ${part_dirs[@]}; do
+    if [ ! -f $part/.done ]; then
+        if [ ! -f $part.zip ]; then
+            echo $0: $part.zip is not exists
+            exit 1
+        fi
+
+        (
+            set -e
+            unzip -oqq $part.zip -d $src/
+            touch $part/.done
+        ) &
+    fi
+done
+wait $(jobs -p)
+
+gen_item() {
+    path=${1%.pcm}
+    txt=$path.txt
+    echo -en "$path\t" | perl -pe 's:^./::g;s:/:_:g'
+    echo -en "$1\t"
+    perl -MEncode -ne '$_=encode("utf-8", decode("cp949", $_)); chomp; @dict=();
+         s:\r::g; # remove LF
+         for(m:(\(.+?\)/\(.+?\)):) { push @dict, $1; }
+         $d=join "\t",@dict; # gather up filler words.
+         print "$_\t$d\n";' $txt
+}
+export -f gen_item
+
+echo -n "$0: Generating files.info "
+iter=0
+old_iter=0
+files_info=()
+for part_dir in ${part_dirs[@]}; do
+    files_info+=($part_dir/files.info)
+    if [ ! -s "$part_dir/files.info" ]; then
+        ( find $part_dir -name '*.pcm'| parallel gen_item {} > $part_dir/files.info ) &
+        iter=$[iter+1]
+    fi
+
+    if [ $old_iter -ne $iter -a $[iter%max_gen] -eq 0 ]; then
+        echo -n .
+        wait $(jobs -p)
+    fi
+    old_iter=$iter
+done
+echo
+wait $(jobs -p)
+
+echo -n "$0: Generating kspon dataset from files.info "
+:>$dst/wav.scp.tmp>$dst/text.tmp>$dst/utt2spk.tmp>$dst/pronoun.dict.tmp
+for info in ${files_info[@]}; do
+    echo -n .
+    awk -F'\t' '{print $1 " " $1}' $info >>$dst/utt2spk.tmp || exit 1
+
+    # Ref. http://ai-hub.promptech.co.kr/notice_product/569
+    perl -F'\t' -ane '#next if ($F[2] =~ m:u/:); # Skip the inaudiable(or unclear) utterance of sentence
+         $F[2] =~ s:(\d+)\s*/\s*(\d+):\2 분에 \1:g; #Chagne division mark
+         $F[2] =~ s:\.+:.:g; # remove multi-dots
+         $F[2] =~ s:([a-zA-Z])\.([a-zA-Z])\.:\1\2:g; # e.g., D.C.
+         $F[2] =~ s:u/::g; # Unclear utterance of sentence mark
+         $F[2] =~ s:o/::g; # Noise mark of utterance
+         $F[2] =~ s:[lbn]/::g; # Breath, laugh, BG noise mark
+         $F[2] =~ s:([가-힣]+?)/:\1:g; # Replace a interjection(filler words)
+         $F[2] =~ s:\+::g; # Utterance repetation mark
+         $F[2] =~ s:\Q*\E::g; # Unclear words utterance mark
+         $F[2] =~ s:[\?\#\!,]::g; # Some other symbols
+         $F[2] =~ s:([^\d])\.([^\d]):\1\2:g; # Remove dot with non-numbers
+         $F[2] =~ s:([\d])\.([^\d ]):\1\2:g; # Remove dot with non-numbers
+         $F[2] =~ s:([^\d ])\.([\d]):\1\2:g; # Remove dot with non-numbers
+         #$F[2] =~ s:\((.+?)\)/\((.+?)\):\1:g; #representation (it needs too much exception)
+         $F[2] =~ s:\((.+?)\)/\((.+?)\):\2:g; #representation
+         $F[2] =~ s:([\w가-힣])-([\w가-힣]):\1 \2:g; #remove hyphen mark used to join words
+         $F[2] =~ s:/::g; # remove some slash
+         $F[2] =~ s:^[\s\.]+::g; # trim left
+         $F[2] =~ s:[\s\.]+$::g; # trim right
+         $F[2] =~ s: +: :g; # remove multi-spaces
+         print "$F[0] $F[2]\n";' $info >>$dst/text.tmp || exit 1
+    awk -F'\t' '{print $1 " sox -t raw -r 16k -b 16 -e signed-integer -L \"" $2 "\" -t wav - | "}' $info >>$dst/wav.scp.tmp || exit 1
+    cut -f4- $info | perl -lane 'next if(/^$/); print "$1\t$2" if(/\(\s*(.+?)\s*\)\/\(\s*(.+?)\s*\)/)' >>$dst/pronoun.dict.tmp || exit 1
+done
+echo
+
+echo $0: Sorting kspon dataset
+env LC_ALL=C sort -u $dst/pronoun.dict.tmp > $dst/pronoun.dict
+env LC_ALL=C sort -u $dst/text.tmp > $dst/text.tmp2
+env LC_ALL=C sort -u $dst/utt2spk.tmp > $dst/utt2spk.tmp2
+env LC_ALL=C sort -u $dst/wav.scp.tmp > $dst/wav.scp.tmp2
+
+echo $0: Filtering inaudiable data
+mv $dst/text.tmp2 $dst/text
+utils/filter_scp.pl $dst/text $dst/utt2spk.tmp2 > $dst/utt2spk || exit 1
+utils/filter_scp.pl $dst/text $dst/wav.scp.tmp2 > $dst/wav.scp || exit 1
+rm -f $dst/*.tmp $dst/*.tmp2
+
+echo $0: Generating spk2utt from utt2spk
+utils/utt2spk_to_spk2utt.pl <$dst/utt2spk >$dst/spk2utt || exit 1
+echo $0: Generating utt2dur
+utils/data/get_utt2dur.sh --cmd "$train_cmd" --nj $nj $dst 1>&2 || exit 1
+echo $0: Checking data
+utils/validate_data_dir.sh --no-feats $dst || exit 1;
+
+echo $0: done
+exit 0

--- a/s5/local/prepare_dict.sh
+++ b/s5/local/prepare_dict.sh
@@ -21,6 +21,10 @@ lexicon_raw_nosil=$dst_dir/lexicon_raw_nosil.txt
 
 if [[ ! -s "$lexicon_raw_nosil" ]]; then
 	cp $lm_dir/zeroth_lexicon $lexicon_raw_nosil || exit 1
+	if [ -s $lm_dir/extra_lexicon ]; then
+		env LC_ALL=C sort -u $lexicon_raw_nosil $lm_dir/extra_lexicon > $lexicon_raw_nosil.tmp
+		mv -f $lexicon_raw_nosil.tmp $lexicon_raw_nosil
+	fi
 fi
 
 silence_phones=$dst_dir/silence_phones.txt

--- a/s5/run_kspon.sh
+++ b/s5/run_kspon.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+#
+# Based mostly on the WSJ/Librispeech recipe. The training databases are #####,
+# zeroth dataset(which consists of 51hrs korean speech with cleaned automatic transcripts) and
+# kspon dataset(which consists of 1000hrs korean speech and transcriptions with 2000 speakers).
+#
+# http://www.openslr.org/resources (Mirror).
+#
+# Copyright  2017  Atlas Guide (Author : Lucas Jo)
+#            2017  Gridspace Inc. (Author: Wonkyum Lee)
+#            2019  hwiorn <hwiorn@gmail.com>
+#
+# Apache 2.0
+#
+
+# Check list before start
+# 1. locale setup
+# 2. pre-installed package: awscli, flac, sox, same cuda library, unzip
+# 3. pre-install or symbolic link for easy going: rirs_noises.zip (takes pretty long time)
+# 4. parameters: nCPU, num_jobs_initial, num_jobs_final, --max-noises-per-minute
+
+zeroth_data=./speechDATA
+kspon_data=./kspon
+nCPU=16
+
+. ./cmd.sh
+. ./path.sh
+
+# you might not want to do this for interactive shells.
+set -e
+
+if [ ! -d "$kspon_data" ]; then
+	echo "No AI-Hub kspon speech dataset was provided."
+	echo "You need to download all korean speech datasets(ZIP files) to \"$kspon_data\" directory from AI-Hub first."
+	echo "   http://www.aihub.or.kr/content/552"
+	exit 1
+fi
+
+startTime=$(date +'%F-%H-%M')
+echo "started at" $startTime
+
+# download the audio data and LMs
+local/download_from_openslr.sh $zeroth_data
+
+# format the data as Kaldi data directories
+for part in train_data_01 test_data_01; do
+	# use underscore-separated names in data directories.
+	local/data_prep.sh $zeroth_data/$part data/$(echo $part | sed s/-/_/g)
+done
+
+# Prepare aihub-kspon dataset
+local/kspon_data_prep.sh --nj $nCPU $kspon_data data/kspon
+
+# update segmentation of transcripts
+:>data/local/lm/extra_lexicon
+for part in train_data_01 test_data_01 kspon; do
+	local/updateSegmentation.sh data/$part data/local/lm
+	local/generateExtraLexicon.sh data/$part data/local/lm
+
+	if [ -s data/$part/extra_lexicon ]; then
+		env LC_ALL=C sort -u data/$part/extra_lexicon data/local/lm/extra_lexicon > data/local/lm/extra_lexicon.tmp
+		mv -f data/local/lm/extra_lexicon.tmp data/local/lm/extra_lexicon
+	fi
+done
+
+# prepare dictionary and language model 
+local/prepare_dict.sh data/local/lm data/local/dict_nosp
+
+utils/prepare_lang.sh data/local/dict_nosp \
+	"<UNK>" data/local/lang_tmp_nosp data/lang_nosp
+
+local/format_lms.sh --src-dir data/lang_nosp data/local/lm
+
+# Create ConstArpaLm format language model for full 3-gram and 4-gram LMs
+# it takes long time and do this again after computing silence prob.
+# you can do comment out here this time
+
+#utils/build_const_arpa_lm.sh data/local/lm/zeroth.lm.tg.arpa.gz \
+#	data/lang_nosp data/lang_nosp_test_tglarge
+#utils/build_const_arpa_lm.sh data/local/lm/zeroth.lm.fg.arpa.gz \
+#	  data/lang_nosp data/lang_nosp_test_fglarge
+
+# Feature extraction (MFCC)
+mfccdir=mfcc
+hostInAtlas="ares hephaestus jupiter neptune"
+if [[ ! -z $(echo $hostInAtlas | grep -o $(hostname -f)) ]]; then
+  mfcc=$(basename mfccdir) # in case was absolute pathname (unlikely), get basename.
+  utils/create_split_dir.pl /mnt/{ares,hephaestus,jupiter,neptune}/$USER/kaldi-data/zeroth-kaldi/s5/$mfcc/storage \
+    $mfccdir/storage
+fi
+for part in train_data_01 test_data_01 kspon; do
+	steps/make_mfcc.sh --cmd "$train_cmd" --nj $nCPU data/$part exp/make_mfcc/$part $mfccdir
+	steps/compute_cmvn_stats.sh data/$part exp/make_mfcc/$part $mfccdir
+done
+
+# ... and then combine data sets into one (for later extension)
+utils/combine_data.sh \
+  data/train_clean data/train_data_01 data/kspon
+
+utils/combine_data.sh \
+  data/test_clean data/test_data_01
+
+# Make some small data subsets for early system-build stages.
+utils/subset_data_dir.sh --shortest data/train_clean 2000 data/train_2kshort
+utils/subset_data_dir.sh data/train_clean 5000 data/train_5k
+utils/subset_data_dir.sh data/train_clean 10000 data/train_10k
+
+echo "#### Monophone Training ###########"
+# train a monophone system & align
+steps/train_mono.sh --boost-silence 1.25 --nj $nCPU --cmd "$train_cmd" \
+	data/train_2kshort data/lang_nosp exp/mono
+steps/align_si.sh --boost-silence 1.25 --nj $nCPU --cmd "$train_cmd" \
+	data/train_5k data/lang_nosp exp/mono exp/mono_ali_5k
+
+echo "#### Triphone Training, delta + delta-delta ###########"
+# train a first delta + delta-delta triphone system on a subset of 5000 utterancesa
+# number of maximum pdf, gaussian (under/over fitting)
+#  recognition result 
+steps/train_deltas.sh --boost-silence 1.25 --cmd "$train_cmd" \
+    2000 10000 data/train_5k data/lang_nosp exp/mono_ali_5k exp/tri1
+steps/align_si.sh --nj $nCPU --cmd "$train_cmd" \
+  data/train_10k data/lang_nosp exp/tri1 exp/tri1_ali_10k
+
+echo "#### Triphone Training, LDA+MLLT ###########"
+# train an LDA+MLLT system.
+steps/train_lda_mllt.sh --cmd "$train_cmd" \
+   --splice-opts "--left-context=3 --right-context=3" 2500 15000 \
+   data/train_10k data/lang_nosp exp/tri1_ali_10k exp/tri2b
+
+# Align a 10k utts subset using the tri2b model
+steps/align_si.sh  --nj $nCPU --cmd "$train_cmd" --use-graphs true \
+  data/train_clean data/lang_nosp exp/tri2b exp/tri2b_ali_train_clean
+
+echo "#### Triphone Training, LDA+MLLT+SAT ###########"
+# Train tri3b, which is LDA+MLLT+SAT on 10k utts
+#steps/train_sat.sh --cmd "$train_cmd" 3000 25000 \
+steps/train_sat.sh --cmd "$train_cmd" 4200 40000 \
+  data/train_clean data/lang_nosp exp/tri2b_ali_train_clean exp/tri3b
+
+# Now we compute the pronunciation and silence probabilities from training data,
+# and re-create the lang directory.
+# silence transition probability ...
+steps/get_prons.sh --cmd "$train_cmd" \
+      data/train_clean data/lang_nosp exp/tri3b
+
+utils/dict_dir_add_pronprobs.sh --max-normalize true \
+      data/local/dict_nosp \
+        exp/tri3b/pron_counts_nowb.txt exp/tri3b/sil_counts_nowb.txt \
+          exp/tri3b/pron_bigram_counts_nowb.txt data/local/dict
+
+utils/prepare_lang.sh data/local/dict \
+      "<UNK>" data/local/lang_tmp data/lang
+
+local/format_lms.sh --src-dir data/lang data/local/lm
+
+utils/build_const_arpa_lm.sh \
+      data/local/lm/zeroth.lm.tg.arpa.gz data/lang data/lang_test_tglarge
+utils/build_const_arpa_lm.sh \
+      data/local/lm/zeroth.lm.fg.arpa.gz data/lang data/lang_test_fglarge
+
+# align the entire train_clean using the tri3b model
+steps/align_fmllr.sh --nj $nCPU --cmd "$train_cmd" \
+  data/train_clean data/lang exp/tri3b exp/tri3b_ali_train_clean
+
+echo "#### SAT again on train_clean ###########"
+# train another LDA+MLLT+SAT system on the entire subset
+steps/train_sat.sh  --cmd "$train_cmd" 4200 40000 \
+  data/train_clean data/lang exp/tri3b_ali_train_clean exp/tri4b
+
+# decode using the tri4b model with pronunciation and silence probabilities
+utils/mkgraph.sh \
+  data/lang_test_tgsmall exp/tri4b exp/tri4b/graph_tgsmall
+
+# the size is properly set?
+utils/subset_data_dir.sh data/test_clean 200 data/test_200
+
+for test in test_200; do
+  nspk=$(wc -l <data/${test}/spk2utt)
+  steps/decode_fmllr.sh --nj $nspk --cmd "$decode_cmd" \
+    exp/tri4b/graph_tgsmall data/$test \
+    exp/tri4b/decode_tgsmall_$test
+  #steps/lmrescore.sh --cmd "$decode_cmd" data/lang_test_{tgsmall,tgmed} \
+  #  data/$test exp/tri4b/decode_{tgsmall,tgmed}_$test
+  steps/lmrescore_const_arpa.sh \
+    --cmd "$decode_cmd" data/lang_test_{tgsmall,tglarge} \
+    data/$test exp/tri4b/decode_{tgsmall,tglarge}_$test
+  steps/lmrescore_const_arpa.sh \
+    --cmd "$decode_cmd" data/lang_test_{tgsmall,fglarge} \
+    data/$test exp/tri4b/decode_{tgsmall,fglarge}_$test
+done
+
+# align train_clean_100 using the tri4b model
+steps/align_fmllr.sh --nj $nCPU --cmd "$train_cmd" \
+	  data/train_clean data/lang exp/tri4b exp/tri4b_ali_train_clean
+
+finishTime=$(date +'%F-%H-%M')
+echo "GMM trainig is finished at" $finishTime
+exit
+## online chain recipe using only clean data set
+echo "#### online chain training  ###########"
+## check point: sudo nvidia-smi --compute-mode=3 if you have multiple GPU's
+#local/chain/run_tdnn_1a.sh
+#local/chain/run_tdnn_1b.sh
+#local/chain/multi_condition/run_tdnn_lstm_1e.sh --nj $nCPU
+local/chain/multi_condition/run_tdnn_1n.sh --nj $nCPU 
+#local/chain/run_tdnn_opgru_1c.sh --nj $nCPU
+
+
+finishTime=$(date +'%F-%H-%M')
+echo "DNN trainig is finished at" $finishTime
+echo "started at" $startTime
+echo "finished at" $finishTime
+exit 0;


### PR DESCRIPTION
master 업데이트 후 커밋을 rebase하여 PR를 다시 열었습니다.

[NIA AI오픈 이노베이션 허브](http://www.aihub.or.kr/content/552)에서 제공하는 한국어 음성 데이터셋(1000시간 발화, 2000 발화자)을 사용하는 스크립트를 추가하였습니다.

`run_kspon.sh` 스크립트는 openslr로부터 받은 zeroth 데이터셋도 사용합니다. kspon 데이터셋은 학습시에 사용됩니다. kspon 데이터셋은 현재 총 5파트로 zip파일들로 제공됩니다. `kspon` 디렉토리에 zip파일들이 있다는 전제 하에 작성하였습니다. kspon 데이터셋은 압축 용량은 79G고, 5개 압축 파일 내의 압축 파일로 이루어져 있어, 압축을 다풀면 총 263G 정도(압축파일들 포함) 디스크를 차지합니다.

kspon 데이터셋은 저작권(AI HUB 데이터셋 사용)만 밝히면 배포 목적에 따라 상업용으로도 사용가능한 것 같습니다.
그런데, NIA 산하에서 배포하는 것이기 때문에, 재배포는 허용되지 않을 것이기 때문에, 사용하기 위해서는 직접 다운로드가 필요합니다. kspon 데이터셋 다운로드를 하기 위해서는, 회원가입, 개인(회사)정보 및 사용목적 등록 후, 담당자 승인 절차를 거친 후에, 가능합니다. 